### PR TITLE
http to https in update checking

### DIFF
--- a/dRegions/dRegions.yml
+++ b/dRegions/dRegions.yml
@@ -247,7 +247,7 @@ dRegions:
 
   updateCheck:
     - ^if !<server.has_flag[dRegions.Version.Repo]> {
-      - ~webget "http://one.denizenscript.com/denizen/repo/version/<s@dRegions_Version.yaml_key[id]>" save:page
+      - ~webget "https://one.denizenscript.com/denizen/repo/version/<s@dRegions_Version.yaml_key[id]>" save:page
       - ^flag server "dRegions.Version.Repo:<entry[page].result||unknown>" d:1h
       }
     - ^define repoVersion '<server.flag[dRegions.Version.Repo]||unknown>'


### PR DESCRIPTION
This change prevent this log to appear in console : 
`[16:23:05 INFO]:  ERROR! Comparing text as if it were a number - calculating based on text length
[16:23:05 INFO]: [dRegions]  Update from version 0.41 to <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"><html><head><title>301 Moved Permanently</title></head><body><h1>Moved Permanently</h1><p>The document has moved <a href="https://www.mcmonkey.org/denizen/repo/version/22">here</a>.</p><hr><address>Apache/2.4.25 (Debian) Server at www.mcmonkey.org Port 80</address></body></html>!`